### PR TITLE
Replace monorepo-starter with hosted monorepo-demo portfolio entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ TypeScript types are in `src/types/content.types.ts`.
 pnpm sync-git-metadata
 ```
 
-Fetches the latest release tag and total commit count for every GitHub-hosted project from the public GitHub API, then updates `version` and `commits` in `src/data/web/projects.data.ts` and `src/data/print/projects.data.ts`. The script commits only those two files with a fixed message (`chore: update git metadata`). Web metadata renders as `vX.X.X · N commits`; print shows `version` or `status` only. Repos without releases (`touch-monorepo`, `LLAAB`, `monorepo-starter`) skip version sync but still get commit counts.
+Fetches the latest release tag and total commit count for every GitHub-hosted project from the public GitHub API, then updates `version` and `commits` in `src/data/web/projects.data.ts` and `src/data/print/projects.data.ts`. The script commits only those two files with a fixed message (`chore: update git metadata`). Web metadata renders as `vX.X.X · N commits`; print shows `version` or `status` only. Repos without releases (`touch-monorepo`, `LLAAB`, `monorepo-demo`) skip version sync but still get commit counts.
 
 ---
 

--- a/scripts/sync-git-metadata.ts
+++ b/scripts/sync-git-metadata.ts
@@ -5,9 +5,9 @@ const GITHUB_ORG = 'finografic';
 const API_BASE = 'https://api.github.com';
 
 /** Skip version fetch — no GitHub releases/tags yet. */
-const VERSION_BLOCKLIST = new Set(['touch-monorepo', 'LLAAB', 'monorepo-starter']);
+const VERSION_BLOCKLIST = new Set(['touch-monorepo', 'LLAAB', 'monorepo-demo']);
 
-const GITHUB_PROJECT_NAMES = new Set(['touch-monorepo', 'monorepo-starter', 'LLAAB']);
+const GITHUB_PROJECT_NAMES = new Set(['touch-monorepo', 'monorepo-demo', 'LLAAB']);
 
 const DATA_FILES = ['src/data/web/projects.data.ts', 'src/data/print/projects.data.ts'];
 

--- a/src/data/print/projects.data.ts
+++ b/src/data/print/projects.data.ts
@@ -34,11 +34,10 @@ export const projects: Project[] = [
       'Full-stack IoT product management system. React + Hono + Drizzle ORM + SQLite, hardware relay via USB HID, role-based auth, real-time session management, multi-locale (EN/ES/CA). Raspberry Pi deployment.',
   },
   {
-    name: '@finografic/gli',
-    version: 'v1.25.4',
-    commits: 212,
+    name: 'monorepo-demo',
+    commits: 101,
     status: 'active',
     description:
-      'Git CLI with live-updating terminal PR dashboard. Interactive rebase, branch selection, multi-repo config, clickable PR links.',
+      'Live full-stack demo built from monorepo-starter. React + Hono + Auth.js + Drizzle + i18n + design-system components. Includes AI-generated Markdown, Queensland TMR data visualisation, and supply-chain security scanner demos.',
   },
 ];

--- a/src/data/web/projects.data.ts
+++ b/src/data/web/projects.data.ts
@@ -147,11 +147,11 @@ export const fullstackProjects: Project[] = [
       'Full-stack TypeScript monorepo for an IoT-connected product management and operational control system. React + React Router client with PandaCSS, Hono API server with Drizzle ORM + SQLite, hardware relay integration via USB HID, i18n with dynamic language support (EN/ES/CA), role-based auth, real-time timer and session management, and deployment tooling for Raspberry Pi. Uses pnpm workspaces, Turborepo, and consumes multiple @finografic packages in production.',
   },
   {
-    name: 'monorepo-starter',
-    commits: 14,
-    titleHref: 'https://github.com/finografic/monorepo-starter',
+    name: 'monorepo-demo',
+    commits: 101,
+    titleHref: 'https://github.com/finografic/monorepo-demo',
     description:
-      'Full-stack pnpm monorepo starter with auth, routing, i18n, database, design tokens, OpenAPI docs, and structured logging pre-wired. Vite 7 + React 19 client, Hono API server, Drizzle ORM + SQLite, Auth.js, Panda CSS, and @finografic/design-system. Built as a reference implementation and portfolio demo.',
+      'Live full-stack demo at https://finografic.github.io/monorepo-demo/, built from monorepo-starter, showcasing a reusable TypeScript monorepo architecture with React, Hono, Auth.js, Drizzle ORM, i18n, design-system components, and API/RPC patterns. Includes 3 interactive demos: AI-generated Markdown pipeline, Queensland TMR data visualisation, and supply-chain security scanner demo.',
   },
 ];
 

--- a/src/data/web/projects.data.ts
+++ b/src/data/web/projects.data.ts
@@ -151,7 +151,7 @@ export const fullstackProjects: Project[] = [
     commits: 101,
     titleHref: 'https://github.com/finografic/monorepo-demo',
     description:
-      'Live full-stack demo at https://finografic.github.io/monorepo-demo/, built from monorepo-starter, showcasing a reusable TypeScript monorepo architecture with React, Hono, Auth.js, Drizzle ORM, i18n, design-system components, and API/RPC patterns. Includes 3 interactive demos: AI-generated Markdown pipeline, Queensland TMR data visualisation, and supply-chain security scanner demo.',
+      'Live full-stack demo at https://finografic.github.io/monorepo-demo/, built from monorepo-starter (https://github.com/finografic/monorepo-starter), showcasing a reusable TypeScript monorepo architecture with React, Hono, Auth.js, Drizzle ORM, i18n, design-system components, and API/RPC patterns. Includes 3 interactive demos: AI-generated Markdown pipeline, Queensland TMR data visualisation, and supply-chain security scanner demo.',
   },
 ];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the `monorepo-starter` full-stack project entry with the new hosted `monorepo-demo` portfolio site.

## Changes

**Web CV (`src/data/web/projects.data.ts`)**
- Replaces `monorepo-starter` under Technical Projects → Full-stack Application
- Title links to `https://github.com/finografic/monorepo-demo`
- Description includes the live demo URL (`https://finografic.github.io/monorepo-demo/`) and the three interactive demos (AI Markdown pipeline, Queensland TMR data visualisation, supply-chain security scanner)

**Print / condensed CV (`src/data/print/projects.data.ts`)**
- Replaces `@finografic/gli` with a tighter `monorepo-demo` entry (no hosted URL, to save one-page space)
- Keeps LLAAB, design-system, genx, and touch-monorepo unchanged

**Supporting updates**
- `scripts/sync-git-metadata.ts`: allowlist updated from `monorepo-starter` → `monorepo-demo`
- `README.md`: sync script docs updated accordingly

## Notes

- Commit count set to 101 from the public GitHub API; `pnpm sync-git-metadata` will keep this current going forward.
- `@finografic/gli` remains on the full web CV under CLI & Developer Tools.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2ab7-2c4e-71c9-bd06-ee1d17acf27c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2ab7-2c4e-71c9-bd06-ee1d17acf27c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

